### PR TITLE
Added support for Pi-hole API Token. Fix requests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 You frequently work in the terminal or ssh into your pi-hole host? Wouldn't it be nice to have a useful greeting message?
 
-Just install and add the `pihello <your.pihole.address>` command to your shell's startup script (`.bash_profile`, `.zshenv`, `fish_greeting.fish`, etc.). Next time you open the terminal you'll be greeted by the default _(or your own)_ fancy message!
+Just install and add the `pihello <your.pihole.address> <your.pihole.api-token>` command to your shell's startup script (`.bash_profile`, `.zshenv`, `fish_greeting.fish`, etc.). Next time you open the terminal you'll be greeted by the default _(or your own)_ fancy message!
 
 ## Installation
 
@@ -43,7 +43,7 @@ pip install pihello
 Run a preconfigured display (as seen above):
 
 ```
-pihello <your.pihole.address>
+pihello <your.pihole.address> <your.pihole.api-token>
 ```
 
 ## Usage
@@ -53,35 +53,36 @@ pihello <your.pihole.address>
 To run from the command line for standard HTTP Pi-hole installs:
 
 ```
-pihello <your.pihole.address>
+pihello <your.pihole.address> <your.pihole.api-token>
 ```
 
 To run from the command line with a custom configuration file:
 
 ```
-pihello <your.pihole.address> -f /path/to/config.txt
+pihello <your.pihole.address> <your.pihole.api-token> -f /path/to/config.txt
 ```
 
 To run from the command line for HTTPS Pi-hole installs:
 
 ```
-pihello <your.pihole.address> -p
+pihello <your.pihole.address> <your.pihole.api-token> -p
 ```
 
 To run from the command line for HTTPS Pi-hole installs w/custom path to pihole (e.g. `/pihole` instead of the default `/admin`) :
 
 ```
-pihello <your.pihole.address> -p -u /pihole
+pihello <your.pihole.address> <your.pihole.api-token> -p -u /pihole
 ```
 
 Full command options:
 
 ```
 $ pihello -h
-usage: pihello [-h] [-v] [-i INDENT] [-f FILE] [-c] [-W WIDTH] [-H HEIGHT] [-ts [TIMESTAMP]] [-p] [-u URI] addr
+usage: pihello [-h] [-v] [-i INDENT] [-f FILE] [-c] [-W WIDTH] [-H HEIGHT] [-ts [TIMESTAMP]] [-p] [-u URI] addr token
 
 positional arguments:
   addr                  the address of your Pi-hole
+  token                 your Pi-hole API Token from settings
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -120,7 +121,7 @@ Blocked [fuchsia]{ads_blocked_today}[] out of [lightgreen]{dns_queries_today}[] 
 Run `pihello` with the `-f` flag pointing to the configuration file:
 
 ```
-pihello <your.pihole.address> -f /home/username/path_to/example.txt
+pihello <your.pihole.address> <your.pihole.api-token> -f /home/username/path_to/example.txt
 ```
 
 ### Variable injection
@@ -182,7 +183,7 @@ PiHole API's variables can be easily injected by using curly braces `{ }`.
 
 - Text styling is done by inserting style tags `[ ]`
 - Color prepended by a semicolon `:` indicates a **background color**
-- Color prepended by an underline `_` indicates an **underlined color**  
+- Color prepended by an underline `_` indicates an **underlined color**
   _AFAIK, only supported in Kitty, VTE, mintty and iTerm2._
 
 **Syntax:** `[<style> <foreground_color> :<background_color> _<underline_color>]`
@@ -227,8 +228,8 @@ There is a number of ways to define a color:
 <details>
 <summary><b>Available color names</b></summary>
 
-These are [Xterm](https://jonasjacek.github.io/colors/) color names.  
-Duplicate color names have been removed keeping the last (usually brightest) occurence.  
+These are [Xterm](https://jonasjacek.github.io/colors/) color names.
+Duplicate color names have been removed keeping the last (usually brightest) occurence.
 This list has currently 202 rows.
 
 | Color # | Color name          |    HEX    |        RGB         |
@@ -442,26 +443,27 @@ This list has currently 202 rows.
 
 **PRs welcome!**
 
-Showcase your configuration!  
+Showcase your configuration!
 Submit a PR with your configuration and a screenshot.
 
 ### Installation
 
 1. Install [Poetry](https://python-poetry.org/docs/)
 1. Clone or fork the repo
-1. Install the dependencies  
-   `poetry install`  
+1. Install the dependencies
+   `poetry install`
    _This creates a virtual environment and installs the project into it._
-1. Activate the virtual environment  
+1. Activate the virtual environment
    `poetry shell`
-1. Run the project  
+1. Run the project
    `pihello ...`
 
 ### TODO-list
 
 _In no particular order_
 
-- Authentication for access to more variables
+- ~~Authentication for access to more variables~~
+- Start accessing more variables
 - Justification styling similar to Python's `ljust()` and `rjust()`
 - Use the screen width and height to break up the text
 - Add actual support for indentation

--- a/pihello/cli.py
+++ b/pihello/cli.py
@@ -9,6 +9,7 @@ from pihello import Console, __version__
 def get_args():
     parser = ArgumentParser(prog="pihello")
     parser.add_argument("addr", help="the address of your Pi-hole")
+    parser.add_argument("token", help="your Pi-hole API Token from settings")
     parser.add_argument("-v", "--version", action="version", version=__version__)
     parser.add_argument(
         "-i",
@@ -81,8 +82,8 @@ def flatten_dict(d, tld="") -> dict:
     return new_dict
 
 
-def get_data(addr: str, query: str = "") -> dict:
-    url = f"{addr}/api.php?{query}"
+def get_data(addr: str, token: str, query: str = "") -> dict:
+    url = f"{addr}/api.php?{query}&auth={token}"
     with request.urlopen(url) as res:
         if res.status != 200:
             raise f"HTTP(S) error {res.status}. Check your Pi-hole address and connection."
@@ -107,9 +108,10 @@ Blocked [fuchsia]{ads_blocked_today}[] out of [lightgreen]{dns_queries_today}[] 
 def main():
     args = get_args()
     pihole = "{}://{}/{}".format(args.proto, args.addr, args.uri.strip("/"))
-    versions = flatten_dict(get_data(pihole, query="versions"))
-    recent_blocked = {"recent_blocked": get_data(pihole, query="recentBlocked")}
-    summary = flatten_dict(get_data(pihole))
+    auth_token = args.token
+    versions = flatten_dict(get_data(pihole, auth_token, query="versions"))
+    recent_blocked = {"recent_blocked": get_data(pihole, auth_token, query="recentBlocked")}
+    summary = flatten_dict(get_data(pihole, auth_token, query="summary"))
 
     console = Console(
         args.width,


### PR DESCRIPTION
Necessary due to recent planned changes with the Pi-hole web interface that have now gone into effect: https://pi-hole.net/blog/2022/11/17/upcoming-changes-authentication-for-more-api-endpoints-required/ and https://github.com/pi-hole/AdminLTE/pull/2411/.

Most API calls, including 'status' and 'summary', now require the Pi-hole API token, which can be obtained through the Settings > API page.

Based on the 2nd link above, there may be some further changes in the future here.

Lastly, Python is not something I am incredibly well-versed in these days, but I did my best to follow the conventions and add to the Readme. Feel free to tweak this or offer suggestions, and I can clean up the PR.

Love this little tool and have it in all my startup shell scripts! Out of town and realized it had stopped working, so whipped this up.